### PR TITLE
Updates/fixes for German varieties [n]swissgerman and [n]austrian

### DIFF
--- a/csquotes.def
+++ b/csquotes.def
@@ -9,6 +9,18 @@
 
 % Predefined backend styles
 
+\DeclareQuoteStyle[quotes]{austrian}% verified
+  {\quotedblbase}
+  {\textquotedblleft}
+  [0.05em]
+  {\quotesinglbase}
+  {\fixligatures\textquoteleft}
+\DeclareQuoteStyle[guillemets]{austrian}% verified
+  {\guillemotright}
+  {\guillemotleft}
+  [0.025em]
+  {\guilsinglright}
+  {\guilsinglleft}
 \DeclareQuoteStyle[quotes]{croatian}% verified
   {\quotedblbase}
   {\textquotedblright}
@@ -201,6 +213,7 @@
 
 % Predefined aliases
 
+\DeclareQuoteAlias[quotes]{austrian}{austrian}
 \DeclareQuoteAlias[quotes]{croatian}{croatian}
 \DeclareQuoteAlias[quotes]{danish}{danish}
 \DeclareQuoteAlias[american]{english}{american}
@@ -210,9 +223,9 @@
 \DeclareQuoteAlias[british]{english}{australian}% unsure
 \DeclareQuoteAlias[british]{english}{newzealand}% unsure
 \DeclareQuoteAlias[quotes]{french}{french}
-\DeclareQuoteAlias[quotes]{german}{austrian}
 \DeclareQuoteAlias[quotes]{german}{german}
 \DeclareQuoteAlias[swiss]{german}{swiss}
+\DeclareQuoteAlias[swiss]{german}{swissgerman}
 \DeclareQuoteAlias[guillemets]{italian}{italian}
 \DeclareQuoteAlias[guillemets]{norwegian}{norwegian}
 \DeclareQuoteAlias[brazilian]{portuguese}{brazilian}
@@ -230,12 +243,14 @@
 \DeclareQuoteAlias{british}{ukenglish}
 \DeclareQuoteAlias{german}{ngerman}
 \DeclareQuoteAlias{austrian}{naustrian}
+\DeclareQuoteAlias{swissgerman}{nswissgerman}
 \DeclareQuoteAlias{norwegian}{norsk}
 \DeclareQuoteAlias{norwegian}{nynorsk}
 \DeclareQuoteAlias{portuguese}{portuges}
 
 % Language options
 
+\DeclareQuoteOption{austrian}
 \DeclareQuoteOption{danish}
 \DeclareQuoteOption{english}
 \DeclareQuoteOption{french}

--- a/csquotes.tex
+++ b/csquotes.tex
@@ -144,6 +144,7 @@ This option controls multilingual support. It requires either the \sty{babel} pa
   \toprule
   \multicolumn{1}{@{}H}{Option key} & \multicolumn{1}{@{}H}{Possible values} \\
   \cmidrule(r){1-1}\cmidrule{2-2}
+  austrian	& quotes, guillemets \\
   croatian	& quotes, guillemets, guillemets\*\\
   danish	& quotes, guillemets, topquotes \\
   english	& american, british\\
@@ -620,6 +621,7 @@ If available, this package will load the configuration file \path{csquotes.cfg}.
   \toprule
   \multicolumn{1}{@{}H}{Quote style} & \multicolumn{1}{@{}H}{Style variants} \\
   \cmidrule(r){1-1}\cmidrule{2-2}
+  austrian	& quotes, guillemets \\
   croatian	& quotes, guillemets, guillemets\*\\
   danish	& quotes, guillemets \\
   dutch		& -- \\
@@ -677,15 +679,15 @@ This command may be used in the configuration file or in the document preamble. 
   \multicolumn{1}{@{}H}{Alias} & \multicolumn{1}{@{}H}{Backend style or alias} \\
   \cmidrule(r){1-1}\cmidrule(r){2-2}\cmidrule(r){3-3}\cmidrule{4-4}
   american	& english/american	&
-	  naustrian	& austrian		\\
-  australian	& english/british	&
 	  newzealand	& english/british	\\
-  austrian	& german/quotes		&
+  australian	& english/british	&
 	  ngerman	& german		\\
-  brazil	& brazilian 		&
+  austrian	& austrian/quotes		&
 	  norsk		& norwegian		\\
-  brazilian	& portuguese/brazilian	&
+  brazil	& brazilian 		&
 	  norwegian	& norwegian/guillemets	\\
+  brazilian	& portuguese/brazilian	&
+	  nswissgerman	& siwssgerman		\\
   british	& english/british	&
 	  nynorsk	& norwegian		\\
   canadian	& english/american	&
@@ -699,10 +701,12 @@ This command may be used in the configuration file or in the document preamble. 
   french	& french/quotes		&
 	  swiss		& german/swiss		\\
   german	& german/quotes		&
-	  UKenglish	& british		\\
+	  swissgerman	& german/swiss		\\
   italian	& italian/guillemets	&
-	  USenglish	& american		\\
+	  UKenglish	& british		\\
   mexican	& spanish/mexican	&
+	  USenglish	& american		\\
+  naustrian	& austrian		&
 						\\
   \bottomrule
 \end{tabularx}


### PR DESCRIPTION
- Since some time, babel has support for Swiss German via "swissgerman"
  and "nswissgerman". Support for this is added to csquotes (aliases
  pointing to german/swiss).
- Like [n]german, [n]austrian uses both quotes and guillemets.
  It seems not possible to switch to guillemets for [n]austrian
  via german=guillemets, so I have implemented proper quote styles and
  an option for austrian.
