### PR TITLE
Add support for Polish language

### DIFF
--- a/csquotes.def
+++ b/csquotes.def
@@ -189,6 +189,21 @@
   [0.05em]
   {\quotesinglbase}
   {\textquoteright}
+\DeclareQuoteStyle[guillemets]{polish}
+  {\quotedblbase}
+  {\textquotedblright}
+  {\guillemotleft}
+  {\guillemotright}
+\DeclareQuoteStyle[guillemets*]{polish}
+  {\quotedblbase}
+  {\textquotedblright}
+  {\guillemotright}
+  {\guillemotleft}
+\DeclareQuoteStyle[quotes]{polish}
+  {\quotedblbase}
+  {\textquotedblright}
+  {\quotesinglbase}
+  {\textquoteright}
 \DeclareQuoteStyle[brazilian]{portuguese}% verified
   {\textquotedblleft}
   {\textquotedblright}
@@ -272,6 +287,7 @@
 \DeclareQuoteAlias[swiss]{german}{swissgerman}
 \DeclareQuoteAlias[guillemets]{italian}{italian}
 \DeclareQuoteAlias[guillemets]{norwegian}{norwegian}
+\DeclareQuoteAlias[guillemets]{polish}{polish}
 \DeclareQuoteAlias[brazilian]{portuguese}{brazilian}
 \DeclareQuoteAlias[portuguese]{portuguese}{portuguese}
 \DeclareQuoteAlias[mexican]{spanish}{mexican}
@@ -305,6 +321,7 @@
 \DeclareQuoteOption{italian}
 \DeclareQuoteOption{latvian}
 \DeclareQuoteOption{norwegian}
+\DeclareQuoteOption{polish}
 \DeclareQuoteOption{portuguese}
 \DeclareQuoteOption{spanish}
 \DeclareQuoteOption{swedish}


### PR DESCRIPTION
This pull request adds support for Polish-style quotes, as described in #20.

I have named the main variant (`„«»”`) as `[guillemets]`, the alternative with reversed inner guillemots (`„»«”`) as `[guillemets*]` and the one, which uses single quotation marks for inside quotes (`„‚’”`) as `[quotes]`. If this is not a correct naming scheme, please change.

The variant `[guillemets]` (`„«»”`) is set as the default variant for the Polish language.