### PR TITLE
Improve polyglossia interface

### DIFF
--- a/csquotes.sty
+++ b/csquotes.sty
@@ -207,6 +207,9 @@
 \protected\def\csq@warning#1{%
   \PackageWarning{csquotes}{#1}}
 
+\protected\def\csq@warning@noline#1{%
+  \PackageWarningNoLine{csquotes}{#1}}
+
 \protected\def\csq@info#1{%
   \iftoggle{csq@quiet}
     {}
@@ -778,20 +781,33 @@
      \endgroup}}
 
 \def\csq@resetstyle{%
+  \ifundef\babelname
+    {\csq@resetstyle@i{\languagename}}%
+    {\csq@resetstyle@i{\babelname}}}
+
+\def\csq@resetstyle@i#1{%
+  \begingroup
+  \edef\csq@tempa{\endgroup
+    \noexpand\csq@resetstyle@ii{#1}}%
+  \csq@tempa}
+
+\def\csq@resetstyle@ii#1{%
   \ifnum\csq@reset=\@ne
-    \ifx\csq@currentstyle\languagename
+    \ifx\csq@currentstyle#1
     \else
-      \ifcsundef{csq@qstyle@\languagename}
-        {\csq@warn@style\languagename
+      \ifcsundef{csq@qstyle@#1}
+        {\csq@warn@style#1
          \csq@setstyle{fallback}}
-        {\csq@setstyle{\languagename}}%
+        {\csq@setstyle{#1}}%
     \fi
   \fi}
 
 \def\csq@savelang{%
   \ifdef\csq@mainlang
     {}
-    {\edef\csq@mainlang{\languagename}}}
+    {\ifdef\babelname
+       {\edef\csq@mainlang{\babelname}}
+       {\edef\csq@mainlang{\langname}}}}
 
 \def\csq@resetlang{%
   \ifdef\csq@mainlang
@@ -1139,10 +1155,10 @@
     {\csq@getpunct{%
        \ifboolexpr{ bool {inner} and bool {hmode} }
          {\csq@bquote@ii}
-	 {\ifbool{csdisplay}
-	    {\csq@bquote@i}
-	    {\iftoggle{csq@parbox}\csq@bquote@ii\csq@bquote@i}}%
-	 {#1}{#2}{#3}{#4}{#5}{#6}}}}
+         {\ifbool{csdisplay}
+            {\csq@bquote@i}
+            {\iftoggle{csq@parbox}\csq@bquote@ii\csq@bquote@i}}%
+         {#1}{#2}{#3}{#4}{#5}{#6}}}}
 
 % {<init>}{<endinit>}{<citehook>}{<cite>}{<punct>}{<text>}{<apunct>}<tpunct>
 
@@ -1325,8 +1341,8 @@
     {\ifdimgreater\lastskip\z@
        {\unskip\unspace}
        {\ifnumgreater\lastpenalty\z@
-	  {\unpenalty\unspace}
-	  {}}}
+          {\unpenalty\unspace}
+          {}}}
     {}}
 
 % {<punct>}{<cite>}
@@ -1762,8 +1778,8 @@
         \def\@inpenc@undefined@##1{\def\inputencodingname{##1}}%
         \@inpenc@undefined
         \ifdefstring\inputencodingname{utf8}
-	  {\aftergroup\@firstoftwo}
-	  {\aftergroup\@secondoftwo}%
+          {\aftergroup\@firstoftwo}
+          {\aftergroup\@secondoftwo}%
         \endgroup}}}
   {\def\csq@ifutfenc{%
      \csq@ifucs
@@ -2138,7 +2154,7 @@
   \def\openinnerquote{\csq@pdf@oiqmark}%
   \def\closeinnerquote{\csq@pdf@ciqmark}}
 
-%% Author interface to internal marks 
+%% Author interface to internal marks
 
 \newrobustcmd*{\initoquote}{%
   \csq@resetstyle
@@ -2250,7 +2266,14 @@
   \@ifpackageloaded{polyglossia}
     {\@ifpackagelater{polyglossia}{2009/11/20}
        {\let\@frenchquotespace\@empty}
-       {}}
+       {}%
+     \@ifpackagelater{polyglossia}{2019/10/27}
+       {}
+       {\csq@warning@noline{%
+          Outdated 'polyglossia' version detected.\MessageBreak
+          csquotes works best with 'polyglossia' v1.45\MessageBreak
+          (2019/10/27) or above, but you are using\MessageBreak
+          '\csuse{ver@polyglossia.sty}'}}}
     {}}
 
 % German
@@ -2392,19 +2415,21 @@
     {\csq@info{Checking for multilingual support..}%
      \@ifpackageloaded{polyglossia}
        {\csq@info{... found 'polyglossia' package}%
-	\def\csq@main@language{\xpg@main@language}%
-	\csq@hook@multilang}
+        \ifundef\mainbabelname
+          {\def\csq@main@language{\xpg@main@language}}
+          {\def\csq@main@language{\mainbabelname}}%
+        \csq@hook@multilang}
        {\@ifpackageloaded{babel}
-	  {\csq@info{... found 'babel' package}%
+          {\csq@info{... found 'babel' package}%
            \def\csq@main@language{\bbl@main@language}%
            \csq@hook@multilang}
-	  {\csq@info{... none found}%
+          {\csq@info{... none found}%
            \csq@hook@nomultilang}}}
     {\@ifpackageloaded{polyglossia}
        {}
        {\@ifpackageloaded{babel}
-	  {}
-	  {\csq@hook@nomultilang}}}%
+          {}
+          {\csq@hook@nomultilang}}}%
   \undef\csq@hook@multilang
   \undef\csq@hook@nomultilang
   \@ifpackageloaded{hyperref}

--- a/csquotes.tex
+++ b/csquotes.tex
@@ -136,7 +136,7 @@ This option selects a fixed quotation style. The style is used throughout the do
 
 \optitem[tryonce]{autostyle}{\opt{true}, \opt{false}, \opt{try}, \opt{once}, \opt{tryonce}}
 
-This option controls multilingual support. It requires either the \sty{babel} package or the \sty{polyglossia} package.\footnote{Note that \sty{polyglossia} support is currently in a preliminary state because \sty{polyglossia} is lacking a proper interface for other packages. In practice, this means that \sty{csquotes} can detect the language (\eg \texttt{english}) but not the language variant (\eg \texttt{british}).} \kvopt{autostyle}{true} continuously adapts the quote style to the current document language; \opt{once} will only adapt the style once so that it matches the main language of the document. \kvopt{autostyle}{try} and \opt{tryonce} are similar to \opt{true} and \opt{once} if multilingual support is available but will not issue any warnings if not (\ie if neither \sty{babel} nor \sty{polyglossia} have been loaded). The short form \opt{autostyle} is equivalent to \kvopt{autostyle}{true}. See also \secref{bas:set}.
+This option controls multilingual support. It requires either the \sty{babel} package or the \sty{polyglossia} package.\footnote{Note that \sty{polyglossia} support requires \sty{polyglossia}~v1.45 (2019/10/27) or above. With older \sty{polyglossia} versions language variants will not be detected as expected.} \kvopt{autostyle}{true} continuously adapts the quote style to the current document language; \opt{once} will only adapt the style once so that it matches the main language of the document. \kvopt{autostyle}{try} and \opt{tryonce} are similar to \opt{true} and \opt{once} if multilingual support is available but will not issue any warnings if not (\ie if neither \sty{babel} nor \sty{polyglossia} have been loaded). The short form \opt{autostyle} is equivalent to \kvopt{autostyle}{true}. See also \secref{bas:set}.
 
 \begin{table}
 \tablesetup
@@ -1562,6 +1562,9 @@ The scope of these hooks must always be confined to a group.
 This revision history is a list of changes relevant to users of this package. Changes of a more technical nature which do not affect the user interface or the behavior of the package are not included in the list. If an entry in the revision history states that a feature has been \emph{extended}, this indicates a syntactically backwards compatible modification, such as the addition of an optional argument to an existing command. Entries stating that a feature has been \emph{modified}, \emph{renamed}, or \emph{removed} demand attention. They indicate a modification which may require changes to existing documents in some, hopefully rare, cases. The \opt{version} option from \secref{opt:opt} may be helpful in this case. The numbers on the right indicate the relevant section of this manual.
 
 \begin{changelog}
+\begin{release}{5.??}{2019-??-??}
+\item Improved \sty{polyglossia} support\see{opt:opt}
+\end{release}
 
 \begin{release}{5.2d}{2018-04-13}
 \item Update for \LaTeX{} kernel changes in 2018


### PR DESCRIPTION
Use `polygossia`'s new `babel`-equivalent language name interface.

Only works with `polyglossia` 1.45 (2019/20/27) or above, but the code is fully backwards compatible with older versions (naturally, variant detection will fail then).

See also #4.

Plus a few whitespace-only changes that turned the last tabs in `csquotes.sty` into spaces.