### PR TITLE
Fix \languagename issue

### DIFF
--- a/csquotes.sty
+++ b/csquotes.sty
@@ -781,25 +781,21 @@
      \endgroup}}
 
 \def\csq@resetstyle{%
-  \ifundef\babelname
-    {\csq@resetstyle@i{\languagename}}%
-    {\csq@resetstyle@i{\babelname}}}
+  \ifnum\csq@reset=\@ne
+    \ifundef\babelname
+      {\ifundef\languagename
+         {\csq@warn@multilang{Cannot detect current language}}
+         {\csq@resetstyle@i{\languagename}}}%
+      {\csq@resetstyle@i{\babelname}}%
+  \fi}
 
 \def\csq@resetstyle@i#1{%
-  \begingroup
-  \edef\csq@tempa{\endgroup
-    \noexpand\csq@resetstyle@ii{#1}}%
-  \csq@tempa}
-
-\def\csq@resetstyle@ii#1{%
-  \ifnum\csq@reset=\@ne
-    \ifx\csq@currentstyle#1
-    \else
-      \ifcsundef{csq@qstyle@#1}
-        {\csq@warn@style#1
-         \csq@setstyle{fallback}}
-        {\csq@setstyle{#1}}%
-    \fi
+  \ifx\csq@currentstyle#1
+  \else
+    \ifcsundef{csq@qstyle@#1}
+      {\csq@warn@style#1
+       \csq@setstyle{fallback}}
+      {\csq@setstyle{#1}}%
   \fi}
 
 \def\csq@savelang{%

--- a/csquotes.sty
+++ b/csquotes.sty
@@ -790,7 +790,7 @@
   \fi}
 
 \def\csq@resetstyle@i#1{%
-  \ifx\csq@currentstyle#1
+  \ifx\csq@currentstyle#1\relax
   \else
     \ifcsundef{csq@qstyle@#1}
       {\csq@warn@style#1


### PR DESCRIPTION
`\languagename` and `\babelname` should only be used if the multi-lingual feature is turned on and even then we had better test if the commands exists. In any case they shouldn't be expanded.

Not sure if https://github.com/josephwright/csquotes/commit/266ebd129e15daff42d3841190be77cccaf20573 is the best way to get rid of the spurious space. A possible alternative would have been
```latex
\def\csq@resetstyle@i#1{%
  \ifx\csq@currentstyle#1%
  \else
    ...
  \fi}
```