### PR TITLE
Fix \languagename typo

### DIFF
--- a/csquotes.sty
+++ b/csquotes.sty
@@ -803,7 +803,9 @@
     {}
     {\ifdef\babelname
        {\edef\csq@mainlang{\babelname}}
-       {\edef\csq@mainlang{\langname}}}}
+       {\ifdef\languagename
+          {\edef\csq@mainlang{\languagename}}
+          {\csq@warn@multilang{Cannot detect main document language}}}}}
 
 \def\csq@resetlang{%
   \ifdef\csq@mainlang


### PR DESCRIPTION
`\langname` does not exist.

Fixes https://github.com/josephwright/csquotes/issues/30.