### PR TITLE
Expand \csq@mainlang (#35)

### DIFF
--- a/csquotes.sty
+++ b/csquotes.sty
@@ -807,18 +807,21 @@
           {\edef\csq@mainlang{\languagename}}
           {\csq@warn@multilang{Cannot detect main document language}}}}}
 
+\newcommand*{\csq@otherlang@star}{\csuse{otherlanguage*}}
+\newcommand*{\csq@otherlang@star@end}{\csuse{endotherlanguage*}}
+
 \def\csq@resetlang{%
   \ifdef\csq@mainlang
-    {\csuse{otherlanguage*}{\csq@mainlang}%
+    {\expandafter\csq@otherlang@star\expandafter{\csq@mainlang}%
      \let\csq@resetlang\relax}
     {}}
 
 \protected\long\def\csq@switchlang#1{%
   \ifdef\csq@mainlang
     {\begingroup
-     \csuse{otherlanguage*}{\csq@mainlang}%
+     \expandafter\csq@otherlang@star\expandafter{\csq@mainlang}%
      #1%
-     \csuse{endotherlanguage*}%
+     \csq@otherlang@star@end
      \endgroup}
     {#1}}
 
@@ -826,9 +829,9 @@
 
 \def\csq@lang#1{%
   \csq@savelang
-  \lowercase{\csuse{otherlanguage*}{#1}}}
+  \lowercase{\csq@otherlang@star{#1}}}
 \def\csq@endlang{%
-  \csuse{endotherlanguage*}}
+  \csq@otherlang@star@end}
 
 \def\csq@nolang#1{%
   \begingroup


### PR DESCRIPTION
`\csq@mainlang` should be expanded when it is passed to `otherlanguage*`.

This should fix https://github.com/josephwright/csquotes/issues/35.