### PR TITLE
Do not blindly lowercase language names

### DIFF
--- a/csquotes.sty
+++ b/csquotes.sty
@@ -829,8 +829,10 @@
 % if not, it is returned as is. This works around issues with uppercased language
 % names e.g. in page headers of book.cls et al., while letting mixed-case language
 % names such as USenglish untouched.
-\def\csq@checkuc#1{%
-  \ifx#1{\MakeUppercase{#1}}
+\def\csq@lc@if@uc#1{%
+ \def\tempa{#1}%
+ \def\tempb{\MakeUppercase{#1}}%
+  \ifx\tempa\tempb
      \lowercase{#1}%
   \else
      #1%
@@ -838,24 +840,24 @@
 
 \def\csq@lang#1{%
   \csq@savelang
-  \csuse{otherlanguage*}{\csq@checkuc{#1}}}
+  \csuse{otherlanguage*}{\csq@lc@if@uc{#1}}}
 \def\csq@endlang{%
   \csq@otherlang@star@end}
 
 \def\csq@nolang#1{%
   \begingroup
-  \def\csq@tempa{\csq@checkuc{#1}}%
+  \def\csq@tempa{\csq@lc@if@uc{#1}}%
   \csq@warn@multilang{Cannot switch to language '\csq@tempa'}%
   \endgroup}
 
 \def\csq@hyph#1{%
   \csq@savelang
-  \csq@hyphenrules{\csq@checkuc{#1}}}
+  \csq@hyphenrules{\csq@lc@if@uc{#1}}}
 \let\csq@endhyph\@empty
 
 \def\csq@nohyph#1{%
   \begingroup
-  \def\csq@tempa{\csq@checkuc{#1}}%
+  \def\csq@tempa{\csq@lc@if@uc{#1}}%
   \csq@warn@multilang{No hyphenation rules for '\csq@tempa'}%
   \endgroup}
 

--- a/csquotes.sty
+++ b/csquotes.sty
@@ -830,13 +830,15 @@
 % names e.g. in page headers of book.cls et al., while letting mixed-case language
 % names such as USenglish untouched.
 \def\csq@lc@if@uc#1{%
- \def\tempa{#1}%
- \def\tempb{\MakeUppercase{#1}}%
-  \ifx\tempa\tempb
+ \begingroup
+ \def\csq@tempa{#1}%
+ \def\csq@tempb{\MakeUppercase{#1}}%
+  \ifx\csq@tempa\csq@tempb
      \lowercase{#1}%
   \else
      #1%
-  \fi}
+  \fi%
+  \endgroup}
 
 \def\csq@lang#1{%
   \csq@savelang

--- a/csquotes.sty
+++ b/csquotes.sty
@@ -808,28 +808,37 @@
      \endgroup}
     {#1}}
 
-% \lowercase: workaround for page headers of book.cls et al.
+% The following checks if a string is completely uppercase. If so, it is lowecased,
+% if not, it is returned as is. This works around issues with uppercased language
+% names e.g. in page headers of book.cls et al., while letting mixed-case language
+% names such as USenglish untouched.
+\def\csq@checkuc#1{%
+  \ifx#1{\MakeUppercase{#1}}
+     \lowercase{#1}%
+  \else
+     #1%
+  \fi}
 
 \def\csq@lang#1{%
   \csq@savelang
-  \lowercase{\csuse{otherlanguage*}{#1}}}
+  \csuse{otherlanguage*}{\csq@checkuc{#1}}}
 \def\csq@endlang{%
   \csuse{endotherlanguage*}}
 
 \def\csq@nolang#1{%
   \begingroup
-  \lowercase{\def\csq@tempa{#1}}%
+  \def\csq@tempa{\csq@checkuc{#1}}%
   \csq@warn@multilang{Cannot switch to language '\csq@tempa'}%
   \endgroup}
 
 \def\csq@hyph#1{%
   \csq@savelang
-  \lowercase{\csq@hyphenrules{#1}}}
+  \csq@hyphenrules{\csq@checkuc{#1}}}
 \let\csq@endhyph\@empty
 
 \def\csq@nohyph#1{%
   \begingroup
-  \lowercase{\def\csq@tempa{#1}}%
+  \def\csq@tempa{\csq@checkuc{#1}}%
   \csq@warn@multilang{No hyphenation rules for '\csq@tempa'}%
   \endgroup}
 


### PR DESCRIPTION
Rather than that, only do that if they are completely uppercased
(which is probably the cause of a `\MakeUppercase` e.g. in headings)

This assures mixed-case names such as `USenglish` are treated correctly

Fixes issue #12.

This revokes https://github.com/josephwright/csquotes/pull/13 which was screwed.

I've addressed https://github.com/josephwright/csquotes/pull/13#commitcomment-21961330

If you dislike the approach in general, feel free to close this.