### PR TITLE
Add documentation for Latin

### DIFF
--- a/csquotes.tex
+++ b/csquotes.tex
@@ -155,6 +155,8 @@ This option controls multilingual support. It requires either the \sty{babel} pa
     german                            & quotes, guillemets, swiss                  \\
     hungarian                         &                                            \\
     italian                           & guillemets, quotes                         \\
+    latin                             & \raggedright italianguillemets, germanquotes, germanguillemets,
+                                        britishquotes, americanquotes \tabularnewline
     latvian                           &                                            \\
     norwegian                         & guillemets, quotes                         \\
     polish                            & guillemets, guillemets\*                   \\
@@ -649,6 +651,8 @@ If available, this package will load the configuration file \path{csquotes.cfg}.
     german                             & quotes, guillemets, swiss                  \\
     greek                              & --                                         \\
     italian                            & guillemets, quotes                         \\
+    latin                              & \raggedright italianguillemets, germanquotes, germanguillemets,
+                                         britishquotes, americanquotes \tabularnewline
     norwegian                          & guillemets, quotes                         \\
     portuguese                         & portuguese, brazilian                      \\
     russian                            & --                                         \\
@@ -710,8 +714,9 @@ This command may be used in the configuration file or in the document preamble. 
     french                       & french/quotes                                 & swedish      & swedish/quotes        \\
     german                       & german/quotes                                 & swiss        & german/swiss          \\
     italian                      & italian/guillemets                            & swissgerman  & german/swiss          \\
-    mexican                      & spanish/mexican                               & UKenglish    & british               \\
-    naustrian                    & austrian                                      & USenglish    & american              \\
+    latin                        & latin/italianguillemets                       & UKenglish    & british               \\
+    mexican                      & spanish/mexican                               & USenglish    & american              \\
+    naustrian                    & austrian                                                                             \\
     \bottomrule
   \end{tabularx}
   \caption[Language Aliases]{Language Aliases Defined by Default}


### PR DESCRIPTION
The documentation for Latin has been lost in 9c798ae. It's readded here.