### PR TITLE
Align Croatian quote styles with the new Orthography (IHJJ)

### DIFF
--- a/csquotes.def
+++ b/csquotes.def
@@ -21,23 +21,17 @@
   [0.025em]
   {\guilsinglright}
   {\guilsinglleft}
-\DeclareQuoteStyle[quotes]{croatian}% verified
+\DeclareQuoteStyle[quotes]{croatian}% based on Croatian Orthography by IHJJ (The Institute of Croatian Language and Linguistics)
   {\quotedblbase}
   {\textquotedblright}
-  [0.05em]% unsure
-  {\quotesinglbase}
+  [0.05em]
+  {\textquoteleft}
   {\textquoteright}
-\DeclareQuoteStyle[guillemets]{croatian}% verified
+\DeclareQuoteStyle[guillemets]{croatian}% based on Croatian Orthography by IHJJ (The Institute of Croatian Language and Linguistics)
   {\guillemotright}
   {\guillemotleft}
   [0.025em]
-  {\quotesinglbase}
-  {\textquoteright}
-\DeclareQuoteStyle[guillemets*]{croatian}% verified
-  {\guillemotleft}
-  {\guillemotright}
-  [0.025em]
-  {\quotesinglbase}
+  {\textquoteleft}
   {\textquoteright}
 \DeclareQuoteStyle[quotes]{czech}
   {\quotedblbase}

--- a/csquotes.tex
+++ b/csquotes.tex
@@ -145,7 +145,7 @@ This option controls multilingual support. It requires either the \sty{babel} pa
     \multicolumn{1}{@{}H}{Option key} & \multicolumn{1}{@{}H}{Possible values}     \\
     \cmidrule(r){1-1}\cmidrule{2-2}
     austrian                          & quotes, guillemets                         \\
-    croatian                          & quotes, guillemets, guillemets\*           \\
+    croatian                          & quotes, guillemets                         \\
     czech                             & quotes, guillemets                         \\
     danish                            & quotes, guillemets, topquotes              \\
     english                           & american, british                          \\
@@ -641,7 +641,7 @@ If available, this package will load the configuration file \path{csquotes.cfg}.
     \multicolumn{1}{@{}H}{Quote style} & \multicolumn{1}{@{}H}{Style variants}      \\
     \cmidrule(r){1-1}\cmidrule{2-2}
     austrian                           & quotes, guillemets                         \\
-    croatian                           & quotes, guillemets, guillemets\*           \\
+    croatian                           & quotes, guillemets                         \\
     czech                              & quotes, guillemets                         \\
     danish                             & quotes, guillemets                         \\
     dutch                              & --                                         \\


### PR DESCRIPTION
Summary:
- `quotes` and `guillemets` are aligned with the new Orthography
- `guillemets*` is considered not to be valid