### PR TITLE
Add Japanese Quote Style

### DIFF
--- a/csquotes.def
+++ b/csquotes.def
@@ -176,6 +176,12 @@
   [0.025em]
   {\textquotedblleft}
   {\textquotedblright}
+\DeclareQuoteStyle{japanese}
+  {「}
+  {」}
+  [0pt]
+  {『}
+  {』}
 \DeclareQuoteStyle{latvian}
   {\quotedblbase}
   {\textquotedblright}
@@ -351,6 +357,7 @@
 \DeclareQuoteOption{german}
 \DeclareQuoteOption{icelandic}
 \DeclareQuoteOption{italian}
+\DeclareQuoteOption{japanese}
 \DeclareQuoteOption{latin}
 \DeclareQuoteOption{latvian}
 \DeclareQuoteOption{norwegian}
@@ -515,6 +522,10 @@
 \DeclareQuoteGlyph{TU}{"201F}% = comma quot. mark, double reversed       = n/a
 \DeclareQuoteGlyph{TU}{"2039}% = angle quot. mark, left-pointing single  = \guilsinglleft
 \DeclareQuoteGlyph{TU}{"203A}% = angle quot. mark, right-pointing single = \guilsinglright
+\DeclareQuoteGlyph{TU}{"300C}% = LEFT CORNER BRACKET                     = n/a
+\DeclareQuoteGlyph{TU}{"300D}% = RIGHT CORNER BRACKET                    = n/a
+\DeclareQuoteGlyph{TU}{"300E}% = LEFT WHITE CORNER BRACKET               = n/a
+\DeclareQuoteGlyph{TU}{"300F}% = RIGHT WHITE CORNER BRACKET              = n/a
 
 
 \endinput


### PR DESCRIPTION
Hello.
I added quote style in Japanese.

If there is no problem, would you please merge them?

---

### About `\DeclareQuoteGlyph` command
Although Unicode has [slots for quotation marks used in Japanese](https://www.unicode.org/charts/PDF/U3000.pdf
) (Strictly speaking, in CJK; Chinese, Japanese, and Korea), almost all fonts intended to typeset in non-CJK Language (e.g. Latin Modern, DejaVu, TeX Gyre) may not have the glyphs of them.