### PR TITLE
Update polish variants

### DIFF
--- a/csquotes.def
+++ b/csquotes.def
@@ -203,13 +203,18 @@
 \DeclareQuoteStyle[guillemets]{polish}
   {\quotedblbase}
   {\textquotedblright}
-  {\guillemotleft}
   {\guillemotright}
+  {\guillemotleft}
 \DeclareQuoteStyle[guillemets*]{polish}
   {\quotedblbase}
   {\textquotedblright}
-  {\guillemotright}
   {\guillemotleft}
+  {\guillemotright}
+\DeclareQuoteStyle[oguillemets]{polish}
+  {\guillemotleft}
+  {\guillemotright}
+  {\quotesinglbase}
+  {\textquoteright}
 \DeclareQuoteStyle[quotes]{polish}
   {\quotedblbase}
   {\textquotedblright}

--- a/csquotes.tex
+++ b/csquotes.tex
@@ -159,7 +159,8 @@ This option controls multilingual support. It requires either the \sty{babel} pa
                                         britishquotes, americanquotes \tabularnewline
     latvian                           &                                            \\
     norwegian                         & guillemets, quotes                         \\
-    polish                            & guillemets, guillemets\*                   \\
+    polish                            & guillemets, guillemets\*, quotes, 
+                                        oguillemets                                \\
     portuguese                        & portuguese, brazilian                      \\
     romanian                          &                                            \\
     serbian                           & quotes, guillemets, german                 \\


### PR DESCRIPTION
The default polish variant was based off `PN-83/P-55366` that was [recalled in 2014](https://sklep.pkn.pl/pn-p-55366-1983p.html). Per [PWN](https://web.archive.org/web/20121120220728/http://so.pwn.pl/zasady.php?id=629866) the version that is currently preferred is the inner-pointing guillemets, though others are allowed. This PR switches the default and alternative variants in the package and adds a fourth one described in `PN-83/P-55366` for completeness sake.

After the changes the code
```latex
\documentclass{article}

\usepackage[polish]{babel}
\usepackage{csquotes}

\begin{document}
\enquote{Cytat \enquote{wewnątrz} cytatu}

\setquotestyle[guillemets*]{polish}
\enquote{Cytat \enquote{wewnątrz} cytatu}

\setquotestyle[quotes]{polish}
\enquote{Cytat \enquote{wewnątrz} cytatu}

\setquotestyle[oguillemets]{polish}
\enquote{Cytat \enquote{wewnątrz} cytatu}
\end{document}
```
produces
![image](https://user-images.githubusercontent.com/12128106/164990987-6eaf33c5-5e3f-434c-960d-b245d5fa68f4.png)
