### PR TITLE
Add Slovenian as an option

### DIFF
--- a/csquotes.def
+++ b/csquotes.def
@@ -255,6 +255,18 @@
   [0.05em]
   {\textquoteright}
   {\textquoteright}
+\DeclareQuoteStyle[guillemets]{slovenian}%
+  {\guillemotright}
+  {\guillemotleft}
+  [0.025em]
+  {\guilsinglright}
+  {\guilsinglleft}
+\DeclareQuoteStyle[quotes]{slovenian}%
+  {\quotedblbase}
+  {\textquotedblleft}
+  [0.05em]
+  {\quotesinglbase}
+  {\fixligatures\textquoteleft}
 \DeclareQuoteStyle[mexican]{spanish}
   {\textquotedblleft}
   {\textquotedblright}
@@ -342,6 +354,7 @@
 \DeclareQuoteAlias[brazilian]{portuguese}{brazilian}
 \DeclareQuoteAlias[portuguese]{portuguese}{portuguese}
 \DeclareQuoteAlias[quotes]{serbian}{serbian}
+\DeclareQuoteAlias[guillemets]{slovenian}{slovenian}
 \DeclareQuoteAlias[mexican]{spanish}{mexican}
 \DeclareQuoteAlias[spanish]{spanish}{spanish}
 \DeclareQuoteAlias[quotes]{swedish}{swedish}
@@ -367,6 +380,7 @@
 \DeclareQuoteAlias{norwegian}{nynorsk}
 \DeclareQuoteAlias{portuguese}{portuges}
 \DeclareQuoteAlias{serbian}{serbianc}
+\DeclareQuoteAlias{slovenian}{slovene}
 
 % Language options
 
@@ -386,6 +400,7 @@
 \DeclareQuoteOption{norwegian}
 \DeclareQuoteOption{polish}
 \DeclareQuoteOption{portuguese}
+\DeclareQuoteOption{slovenian}
 \DeclareQuoteOption{spanish}
 \DeclareQuoteOption{swedish}
 

--- a/csquotes.tex
+++ b/csquotes.tex
@@ -163,6 +163,7 @@ This option controls multilingual support. It requires either the \sty{babel} pa
     portuguese                        & portuguese, brazilian                      \\
     romanian                          &                                            \\
     serbian                           & quotes, guillemets, german                 \\
+    slovenian                         & guillemets, quotes                         \\
     spanish                           & spanish, mexican                           \\
     swedish                           & quotes, guillemets, guillemets\*           \\
     \bottomrule


### PR DESCRIPTION
# Quote styles

There are several quote styles available in Slovenian, such as guillemets and quotes, double and single. There are no hard prescriptions, but in general guillemets are used in print, while handwritten text uses (simplified) quotes.

Similarly, inner marks do not need to be the single version of the outer mark. For example, with guillemets as outer marks, double quotes can be used as inner marks (see examples under rule 463 of [Slovenski pravopis, Part I, Pravila](https://fran.si/134/slovenski-pravopis/datoteke/Pravopis_Pravila.pdf)) as well as single quotes (see the fourth bullet point in [this advice](https://svetovalnica.zrc-sazu.si/topic/2418/dvojni-narekovaj-narekovaj-spodaj-zgoraj) from Research Centre of the Slovenian Academy of Sciences and Arts, ZRC SAZU).

With that said, the quotes are prescribed to be written in the 99-66 and 9-6 forms, starting with the lower and ending with the upper mark.

Double upper marks[^1] are only used in the context of linguistics to mark the meaning of a foreign word.

## Selected quote style

To be consistent with some other styles, I chose guillemets as the default style and included the quotes style as an alternative. In both cases, I used the single marks for the inner style.

# Naming of options

There are two options for nouns and adjectives referring to Slovenia: Slovenian and Slovene. They are both equally valid (see [Wikipedia Conventions on this topic](https://en.wikipedia.org/wiki/Wikipedia:Naming_conventions_(Slovenian_vs_Slovene))). In their options, `polyglossia` uses "slovenian", while `babel` uses "slovene".

I chose "slovenian" as the default style name, but added "slovene" as an alias.

[^1]: The two sources differ here, with Pravopis referencing the 9-9 form (see rule 467), while the fifth bullet point in the advice refers to the 6-9 form.
