### PR TITLE
Fix Dutch quotation style

### DIFF
--- a/csquotes.def
+++ b/csquotes.def
@@ -63,11 +63,11 @@
   {\textquoteleft}
   {\textquoteright}
 \DeclareQuoteStyle{dutch}
-  {\quotedblbase}
+  {\textquotedblleft}
   {\textquotedblright}
   [0.05em]
-  {\quotesinglbase}% unsure
-  {\textquoteright}% unsure
+  {\textquoteleft}
+  {\textquoteright}
 \DeclareQuoteStyle[american]{english}% verified
   {\textquotedblleft}
   {\textquotedblright}


### PR DESCRIPTION
Quoting with lower quotes is a very old-school way of quoting in the Dutch language. Following convention set by Onze Taal: https://onzetaal.nl/taalloket/aanhalingstekens-en-leestekens