### PR TITLE
Update csquotes.def

### DIFF
--- a/csquotes.def
+++ b/csquotes.def
@@ -328,6 +328,12 @@
   {\guillemotright}
   {\quotedblbase}
   {\textquotedblleft}
+\DeclareQuoteStyle[british]{welsh}
+  {\textquoteleft}
+  {\textquoteright}
+  [0.05em]
+  {\textquotedblleft}
+  {\textquotedblright}
 
 % Plain style for PDF strings
 
@@ -370,6 +376,7 @@
 \DeclareQuoteAlias[guillemets]{german}{latin/germanguillemets}
 \DeclareQuoteAlias{british}{latin/britishquotes}
 \DeclareQuoteAlias{american}{latin/americanquotes}
+\DeclareQuoteAlias[british]{welsh}{welsh}
 
 % Babel aliases
 
@@ -410,6 +417,7 @@
 \DeclareQuoteOption{slovenian}
 \DeclareQuoteOption{spanish}
 \DeclareQuoteOption{swedish}
+\DeclareQuoteOption{welsh}
 
 % Register quotation marks (per output encoding)
 


### PR DESCRIPTION
Please could you add Welsh? 

By default, I get question marks.

Suggest welsh - british variant because I have no idea if they use different quotes in Welsh in Argentina, but welsh should be an alias for UK Welsh, even if there's a variant required for Yr Wladfa (Patagonia? I tried to check the English using Google translate, but the results were not helpful.). 