### PR TITLE
Add Korean support

### DIFF
--- a/csquotes.def
+++ b/csquotes.def
@@ -182,6 +182,24 @@
   [0pt]
   {『}
   {』}
+\DeclareQuoteStyle[quotes]{korean}
+  {\textquotedblleft}
+  {\textquotedblright}
+  [0.05em]
+  {\textquoteleft}
+  {\textquoteright}
+\DeclareQuoteStyle[corners]{korean}
+  {『}
+  {』}
+  [0em]
+  {「}
+  {」}
+\DeclareQuoteStyle[angles]{korean}
+  {《}
+  {》}
+  [0em]
+  {〈}
+  {〉}
 \DeclareQuoteStyle{latvian}
   {\quotedblbase}
   {\textquotedblright}
@@ -361,6 +379,7 @@
 \DeclareQuoteAlias[swiss]{german}{swiss}
 \DeclareQuoteAlias[swiss]{german}{swissgerman}
 \DeclareQuoteAlias[guillemets]{italian}{italian}
+\DeclareQuoteAlias[quotes]{korean}{korean}
 \DeclareQuoteAlias[guillemets]{norwegian}{norwegian}
 \DeclareQuoteAlias[guillemets]{polish}{polish}
 \DeclareQuoteAlias[brazilian]{portuguese}{brazilian}
@@ -408,6 +427,7 @@
 \DeclareQuoteOption{icelandic}
 \DeclareQuoteOption{italian}
 \DeclareQuoteOption{japanese}
+\DeclareQuoteOption{korean}
 \DeclareQuoteOption{latin}
 \DeclareQuoteOption{latvian}
 \DeclareQuoteOption{lithuanian}

--- a/csquotes.tex
+++ b/csquotes.tex
@@ -154,6 +154,7 @@ This option controls multilingual support. It requires either the \sty{babel} pa
     german                            & quotes, guillemets, swiss                  \\
     hungarian                         &                                            \\
     italian                           & guillemets, quotes                         \\
+    korean                            & quotes, corners, angles                    \\
     latin                             & \raggedright italianguillemets, germanquotes, germanguillemets,
                                         britishquotes, americanquotes \tabularnewline
     latvian                           &                                            \\
@@ -654,6 +655,7 @@ If available, this package will load the configuration file \path{csquotes.cfg}.
     german                             & quotes, guillemets, swiss                  \\
     greek                              & --                                         \\
     italian                            & guillemets, quotes                         \\
+    korean                             & quotes, corners, angles                    \\
     latin                              & \raggedright italianguillemets, germanquotes, germanguillemets,
                                          britishquotes, americanquotes \tabularnewline
     norwegian                          & guillemets, quotes                         \\
@@ -718,9 +720,10 @@ This command may be used in the configuration file or in the document preamble. 
     french                       & french/quotes                                 & swedish      & swedish/quotes        \\
     german                       & german/quotes                                 & swiss        & german/swiss          \\
     italian                      & italian/guillemets                            & swissgerman  & german/swiss          \\
-    latin                        & latin/italianguillemets                       & UKenglish    & british               \\
-    mexican                      & spanish/mexican                               & USenglish    & american              \\
-    naustrian                    & austrian                                      & welsh        & welsh/british         \\
+    korean                       & korean/quotes                                 & UKenglish    & british               \\
+    latin                        & latin/italianguillemets                       & USenglish    & american              \\
+    mexican                      & spanish/mexican                               & welsh        & welsh/british         \\
+    naustrian                    & austrian                                                                             \\
     \bottomrule
   \end{tabularx}
   \caption[Language Aliases]{Language Aliases Defined by Default}


### PR DESCRIPTION
This commit adds Korean styles. There are three variants: `plain`, `corners`, and `angles`.
* `plain` uses quotation marks, which is the same as American English. This fits with modern Korean.
* `corners` uses corner brackets, which is the same as Japanese. This fits with classic (old) Korean and vertiacal typesetting.
* `angles` uses angle brackets. Some special typesetters might use this style variant. It also seems that North Korea uses these symbols.

Sample usage:
```
\documentclass{article}

\usepackage[hangul]{kotex}
\usepackage{csquotes}

\begin{document}

\setquotestyle[quotes]{korean}
\enquote{\enquote{철수}야, \enquote{밥} 먹자!} 하고 철수네 엄마가 불렀다.

\setquotestyle[corners]{korean}
\enquote{\enquote{철수}야, \enquote{밥} 먹자!} 하고 철수네 엄마가 불렀다.

\setquotestyle[angles]{korean}
\enquote{\enquote{철수}야, \enquote{밥} 먹자!} 하고 철수네 엄마가 불렀다.

\end{document}
```

<img width="652" height="150" alt="csquotes-kroean" src="https://github.com/user-attachments/assets/641fae69-9a76-41de-b5c2-61bea4e7ca22" />
